### PR TITLE
move color-scheme from :root to html

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1,7 +1,5 @@
-:root {
-  color-scheme: light dark;
-}
 html {
+  color-scheme: light dark;
   box-sizing: border-box;
   block-size: 100%; /* full-height content */
   text-rendering: optimizeSpeed;


### PR DESCRIPTION
`:root` is the same as `html`
But `:root` has a higher specificity.

See here:
https://css-tricks.com/almanac/selectors/r/root/#points-of-interest